### PR TITLE
fix(ci): fixed double building in release action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,8 +26,6 @@ jobs:
         if: ${{ steps.release.outputs.release_created }}
       - run: npm ci
         if: ${{ steps.release.outputs.release_created }}
-      - run: npm run build
-        if: ${{ steps.release.outputs.release_created }}
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}


### PR DESCRIPTION
The release script does today run the build script two times.

https://github.com/lindell/aoc-loader/runs/1503633621#step:6:9
https://github.com/lindell/aoc-loader/runs/1503633621#step:7:13