### PR TITLE
chore: update renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,12 @@
 {
-  "extends": ["config:base"]
+  "extends": [
+    "config:base",
+    "schedule:quarterly",
+    ":dependencyDashboard",
+    ":unpublishSafe",
+    ":prNotPending",
+    ":automergeBranch",
+    ":automergeLinters",
+    ":automergeTesters"
+  ]
 }


### PR DESCRIPTION
Sets the following Renovate settings: 

- `schedule:quarterly`: Schedule Renovate to run quarterly
- `:dependencyDashboard`: Enables the [Dependency Dashboard](https://docs.renovatebot.com/configuration-options/#dependencydashboard) feature
- `:unpublishSafe`: Set a status check to warn when upgrades < 24 hours old might get unpublished
- `:prNotPending`: Wait until branch tests have passed or failed before creating the PR
- `:automergeBranch`: If automerging, push the new commit directly to base branch (no PR)
- `:automergeLinters`: Update lint packages automatically if tests pass
- `:automergeTesters`: Update testing packages automatically if tests pass