### PR TITLE
chore: replace unpublishSafe with stabilityDays

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,10 +3,10 @@
     "config:base",
     "schedule:quarterly",
     ":dependencyDashboard",
-    ":unpublishSafe",
     ":prNotPending",
     ":automergeBranch",
     ":automergeLinters",
     ":automergeTesters"
-  ]
+  ],
+  "stabilityDays": 3
 }


### PR DESCRIPTION
Replace `unpublishSafe` with `stabilityDays` since it's being removed from Renovate. See https://github.com/renovatebot/renovate/pull/7464