### PR TITLE
chore: stop building and publishing test in package

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,5 +10,5 @@
     "removeComments": true,
     "outDir": "dist"
   },
-  "include": ["*.ts"]
+  "include": ["index.ts"]
 }


### PR DESCRIPTION
This PR stopes TypeScript from building and including the test file in the published package. 

This also fixes an issue with TS, given that you already had built the code locally, it would complain about that `dist/index.d.ts` would overwrite itself when building.